### PR TITLE
This repository should be used for actions on multiple deployments. L…

### DIFF
--- a/bin/in
+++ b/bin/in
@@ -7,7 +7,6 @@ exec 1>&2 # send normal stdout to stderr for logging
 echo "Starting in"
 payload="$(mktemp "$TMPDIR/k8s-resource-request.XXXXXX")"
 cat > "$payload" <&0
-
 cd "$1"
 
 mkdir -p /root/.kube
@@ -33,21 +32,23 @@ if [[ "$KUBE_URL" =~ https.* ]]; then
     KUBECTL="$KUBECTL --certificate-authority=$CA_PATH --client-key=$KEY_PATH --client-certificate=$CERT_PATH"
 fi
 
-# get kube resource id
-RESOURCE_TYPE=$(jq -r .source.resource_type < "$payload")
-RESOURCE_NAME=$(jq -r .source.resource_name < "$payload")
+export KUBECTL
 
-if [[ -z "$RESOURCE_TYPE" ]] || [[ -z "$RESOURCE_NAME" ]]; then
-    result=""
-else
-    export KUBECTL
+DEPLOYMENT_LIST=$(jq -r .source.deployment_list< "$payload")
+SANITIZED_DEPLOYMENT_LIST=`echo $DEPLOYMENT_LIST | sed -e 's,\,,,g' | sed -e 's,\[,,g' | sed -e 's,\],,g' | sed -e 's,\",,g'`
+DEPLOYMENT_ARRAY=($SANITIZED_DEPLOYMENT_LIST)
+echo "The list of deployments passed to this script:"
+echo ${DEPLOYMENT_ARRAY[@]}
 
-    RESOURCE="$RESOURCE_TYPE/$RESOURCE_NAME"
-
+result=`jq -n '{}'`
+for deployment_name in "${DEPLOYMENT_ARRAY[@]}"; do
+    RESOURCE="deployment/$deployment_name"
     IMG=$($KUBECTL get -o json "$RESOURCE" | jq -r '.spec.template.spec.containers[0].image')
-
-    result="$(jq -n "{version:{container:\"$IMG\"}}")"
-fi
+    KEY=$deployment_name
+    VAL=$IMG
+    result=`echo $result | jq --arg a $KEY --arg b $VAL '.version[$a] = $b'`
+    COUNTER=$[$COUNTER + 1]
+done
 
 echo "In complete"
 echo "$result" | jq -s add  >&3

--- a/bin/out
+++ b/bin/out
@@ -9,6 +9,11 @@ echo "Starting out"
 payload="$(mktemp "$TMPDIR/k8s-resource-request.XXXXXX")"
 cat > "$payload" <&0
 
+DRY_RUN=$(jq -r .params.dry_run < "$payload")
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "********************** Running in DRY_RUN mode **********************"
+fi
+
 rollback() {
     DEPLOYMENT=$1
     DRY_RUN=$2
@@ -16,49 +21,6 @@ rollback() {
     echo "Running: $KUBECTL rollout undo deployment/$DEPLOYMENT"
     if [[ "$DRY_RUN" == "null" ]] || [[ "$DRY_RUN" == "false" ]]; then
         $KUBECTL rollout undo "deployment/$DEPLOYMENT"
-    fi
-}
-
-deploy() {
-    DEPLOYMENT=$1
-    CONTAINER=$2
-    IMAGE=$3
-    DEPLOYMENT_PATH=$4
-    IMG_PREFIX=$5
-    DRY_RUN=$6
-
-    [ -n "$DEPLOYMENT" ] || exit 1
-    [ -n "$IMAGE" ] || exit 1
-    [ -n "$CONTAINER" ] || exit 1
-
-    $KUBECTL get deployments --show-labels --output=json > /tmp/deployments.json
-
-    if [[ -n "$DEPLOYMENT_PATH" ]] && [[ "$DEPLOYMENT_PATH" != "null" ]] && [[ -n "$IMG_PREFIX" ]] && [[ "$IMG_PREFIX" != "null" ]]; then
-        echo "Deployment path set to $DEPLOYMENT_PATH"
-        echo "Image prefix set to $IMG_PREFIX"
-        if [[ "$DRY_RUN" == "null" ]] || [[ "$DRY_RUN" == "false" ]]; then
-            cat "${DEPLOYMENT_PATH}" | sed "s~image:[ \t]*\($IMG_PREFIX\/.*\).*~image: $IMAGE~" | $KUBECTL replace --record -f -
-        fi
-    else
-        echo 'Setting image only.'
-        if [[ "$DRY_RUN" == "null" ]] || [[ "$DRY_RUN" == "false" ]]; then
-            $KUBECTL set image "deployment/$DEPLOYMENT" "$CONTAINER=$IMAGE" --record
-        fi
-    fi
-}
-
-start_job() {
-    JOB=$1
-    IMAGE=$2
-    UID=${3:-$(date +%s)}
-    DRY_RUN=$4
-
-    [ -n "$JOB" ] || exit 1
-    [ -n "$IMAGE" ] || exit 1
-    [ -n "$UID" ] || exit 1
-
-    if [[ "$DRY_RUN" == "null" ]] || [[ "$DRY_RUN" == "false" ]]; then
-        cat "$JOB" | IMAGE=$IMAGE UID=$UID envsubst | $KUBECTL create --record -f -
     fi
 }
 
@@ -92,56 +54,19 @@ if [[ "$KUBE_URL" =~ https.* ]]; then
 fi
 
 export KUBECTL
+DEPLOYMENT_LIST=$(jq -r .source.deployment_list< "$payload")
+SANITIZED_DEPLOYMENT_LIST=`echo $DEPLOYMENT_LIST | sed -e 's,\,,,g' | sed -e 's,\[,,g' | sed -e 's,\],,g' | sed -e 's,\",,g'`
+DEPLOYMENT_ARRAY=($SANITIZED_DEPLOYMENT_LIST)
 
 ROLLBACK=$(jq -r .params.rollback < "$payload")
-RESOURCE_TYPE=$(jq -r .source.resource_type < "$payload")
-RESOURCE_NAME=$(jq -r .source.resource_name < "$payload")
-DRY_RUN=$(jq -r .params.dry_run < "$payload")
-
-if [[ -z "$RESOURCE_TYPE" ]]; then
-    RESOURCE_TYPE=$(jq -r .params.resource_type < "$payload")
+if [[ "$ROLLBACK" == "true" ]]; then
+    echo "********************** Method invoked: Rollback **********************"
 fi
 
-if [[ -z "$RESOURCE_NAME" ]]; then
-    RESOURCE_TYPE=$(jq -r .params.resource_name < "$payload")
-fi
-
-if [[ "$RESOURCE_TYPE" = 'deployment' ]]; then
-    if [[ "$ROLLBACK" = "true" ]]; then
-        rollback "$RESOURCE_NAME" "$DRY_RUN";
-    else
-        case $RESOURCE_TYPE in
-            deployment)
-            RESOURCE_PATH=$(jq -r .params.resource_path < "$payload")
-            CONTAINER_NAME=$(jq -r .source.container_name < "$payload")
-            DEPLOYMENT_PATH=$(jq -r .source.deployment_file < "$payload")
-            IMG_PREFIX=$(jq -r .source.image_prefix < "$payload")
-
-            if [[ "$DEPLOYMENT_PATH" == "null" ]]; then
-                DEPLOYMENT_PATH=$(jq -r .params.deployment_file < "$payload")
-            fi
-
-            if [[ "$IMG_PREFIX" == "null" ]]; then
-                IMG_PREFIX=$(jq -r .params.image_prefix < "$payload")
-            fi
-
-            if [[ "$CONTAINER_NAME" == "null" ]]; then
-              CONTAINER_NAME=$RESOURCE_NAME
-            fi
-
-            IMG_FILE=$(jq -r .params.image_name < "$payload")
-            IMG=$(cat "$IMG_FILE")
-            TAG_FILE=$(jq -r .params.image_tag < "$payload")
-            TAG=$(cat "$TAG_FILE")
-            IMG="$IMG:$TAG"
-
-            deploy "$RESOURCE_NAME" "$CONTAINER_NAME" "$IMG" "$DEPLOYMENT_PATH" "$IMG_PREFIX" "$DRY_RUN";;
-            job)
-            start_job "$RESOURCE_PATH" "$IMG" "$(date +%s)" "$DRY_RUN";;
-            *)
-            exit 1
-        esac
-    fi
+if [[ "$ROLLBACK" = "true" ]]; then
+    for deployment_name in "${DEPLOYMENT_ARRAY[@]}"; do
+        rollback $deployment_name "$DRY_RUN";
+    done
 fi
 
 result="$(jq -n "{version:{container:\"$IMG\"}}")"

--- a/push_docker.sh
+++ b/push_docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+IMAGE_ID=$1
+docker tag $IMAGE_ID PeriscopeData/concourse-multiple-kube-deployments:latest
+docker push PeriscopeData/concourse-multiple-kube-deployments:latest


### PR DESCRIPTION
…ook in rollback-jobs pipeline in Concourse (https://concourse.periscopedata.com/teams/deploy/pipelines/rollback-jobs). Pass in a list of deployments from Concourse along with these params:

rollback: value (optional)
	accepted values: true or false

dry_run: value (optional)
	accepted values: true or false

Usage:
	dry_run: true
	rollback: true
	deployment_list:
		- bg-scheduled-completer
    		- bg-scheduled-refresher
   		- clockwork

If dry_run is passed in as true, no Kubectl command is executed. This exists for easier debugging as it still prints information that can be seen on your run in Concourse.